### PR TITLE
chore(gh-actions): Upgrade deploy action

### DIFF
--- a/.github/workflows/deploy-pdf.yml
+++ b/.github/workflows/deploy-pdf.yml
@@ -37,7 +37,7 @@ jobs:
           path: deploy
 
       - name: 🚀 Deploy
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: deploy   # The folder the action should deploy.


### PR DESCRIPTION
The former version was using a deprecated Node version and logging a warning notice.